### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "googletest"
+description := "Google's C++ test framework."
+gitrepo     := "https://github.com/google/googletest.git"
+homepage    := "https://github.com/google/googletest/"
+version     := 1.8.1 sha256:9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c https://github.com/google/googletest/archive/release-1.8.1.tar.gz
+license     := "BSD-3.0-Clause"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

